### PR TITLE
feat: added option to keep directions in graphs

### DIFF
--- a/tomorrowcities/pages/engine.py
+++ b/tomorrowcities/pages/engine.py
@@ -22,7 +22,7 @@ import logging, sys
 import pickle
 import datetime
 from .settings import storage, landslide_max_trials, revive_storage
-from .settings import threshold_flood, threshold_flood_distance, threshold_road_water_height, threshold_culvert_water_height
+from .settings import threshold_flood, threshold_flood_distance, threshold_road_water_height, threshold_culvert_water_height, preserve_edge_directions
 from ..backend.engine import compute, compute_power_infra, compute_road_infra, calculate_metrics, generate_exposure
 from ..backend.utils import building_preprocess, identity_preprocess, ParameterFile
 from .utilities import S3FileBrowser, extension_list, extension_list_w_dots
@@ -1053,7 +1053,7 @@ def ExecutePanel():
                     household_hospital_access, individual_facility_access  = \
                 compute_road_infra(buildings, household, individual, nodes, edges, intensity, 
                 fragility, hazard, threshold_road_water_height.value, threshold_culvert_water_height.value,
-                threshold_flood_distance.value,
+                threshold_flood_distance.value, preserve_edge_directions.value,
                 )
             
             edges['ds'] = list(ds)
@@ -1093,7 +1093,9 @@ def ExecutePanel():
                                     edges,
                                     intensity,
                                     fragility,
-                                    hazard, threshold_flood.value, threshold_flood_distance.value)
+                                    hazard, threshold_flood.value, threshold_flood_distance.value,
+                                    preserve_edge_directions.value,
+                                    )
             
             #power_node_df =  dfs['Power Nodes'].copy()                         
             nodes['ds'] = list(ds)

--- a/tomorrowcities/pages/settings.py
+++ b/tomorrowcities/pages/settings.py
@@ -23,6 +23,7 @@ threshold_flood = solara.reactive(0.2)
 threshold_flood_distance = solara.reactive(10)
 threshold_road_water_height = solara.reactive(0.3) 
 threshold_culvert_water_height = solara.reactive(1.5)
+preserve_edge_directions = solara.reactive(False)
 
 def storage_control(aws_access_key_id: str, aws_secret_access_key: str, region_name: str, bucket_name: str):
     storage.value = S3Storage(aws_access_key_id, aws_secret_access_key, region_name, bucket_name)
@@ -104,6 +105,9 @@ def Page(name: Optional[str] = None, page: int = 0, page_size=100):
 
     if err_message != '':
         solara.Error(err_message)
+
+    with solara.Card(title='Connectivity Parameters',subtitle='Parameters effecting connectivity analysis in road/power networks'):
+        solara.Checkbox(label='Preserve directions in graph edges', value=preserve_edge_directions)
 
     with solara.Card(title='Landslide Parameters',subtitle='Choose the parameters for the landslide simulation'):
         solara.SliderInt(label='Number of Monte-Carlo Trials', value=landslide_max_trials, min=1,max=100)


### PR DESCRIPTION
With this addition, a distinct separation between
directed and undirected graphs is made. The user
can keep the directions in road/network graphs or
allow the engine transform to undirected graphs.
Because of the road/network analysis in the engine, by default the graphs are converted to undirected
graphs. This option can be manipulated via settings page.