### PR TITLE
fix: reset existing index in input dataframes

### DIFF
--- a/tomorrowcities/pages/engine.py
+++ b/tomorrowcities/pages/engine.py
@@ -788,6 +788,8 @@ def import_data(fileinfo: solara.components.file_drop.FileInfo):
             data = pd.read_json(json_string)
 
     if isinstance(data, gpd.GeoDataFrame) or isinstance(data, pd.DataFrame):
+        # reset existing index to avoid conflicts in index-related computations
+        data = data.reset_index(drop=True)
         data.columns = data.columns.str.lower()
         attributes = set(data.columns)
     elif isinstance(data, dict):


### PR DESCRIPTION
If the existing index in the uploaded dataframe is different than the default numeric index starting from 0, then index-based dataframe operations in the engine may produce unexpected results. To be on the safe side, the engine now reset the indexes of every uploaded dataframe.