### PR TITLE
feat: a pre-check if hospitals exist in building

### DIFF
--- a/tomorrowcities/pages/engine.py
+++ b/tomorrowcities/pages/engine.py
@@ -1032,6 +1032,9 @@ def ExecutePanel():
             if unique_records != all_records:
                 return False, "there are duplicate expstr + susceptibility records in landslide fragility"
 
+        missing_hospitals = set(household['commfacid']) - set(building['bldid'])
+        if len(missing_hospitals) > 0:
+            return False, f"Hospital(s) ({missing_hospitals}) do not exist in building data"
         return True, ''
 
     def execute_engine():


### PR DESCRIPTION
If a hospital (commfacid in household layer) is not defined in the building layer, throws an error message.