### PR TITLE
fix: corrected attribute list of power node

### DIFF
--- a/tomorrowcities/pages/engine.py
+++ b/tomorrowcities/pages/engine.py
@@ -168,7 +168,7 @@ def create_new_app_state():
             'attributes_required': [set(['geometry', 'node_id', 'pwr_plant', 'n_bldgs'])],
             'attributes': [set(['geometry', 'fltytype', 'strctype', 'utilfcltyc', 'indpnode', 'guid', 
                          'node_id', 'x_coord', 'y_coord', 'pwr_plant', 'serv_area', 'n_bldgs', 
-                         'income', 'eq_vuln'])]},
+                         'income', 'eq_frgl'])]},
         'power edges': {
             'render_order': 80,
             'data': solara.reactive(None),

--- a/tomorrowcities/pages/explore.py
+++ b/tomorrowcities/pages/explore.py
@@ -160,7 +160,7 @@ def create_new_app_state():
             'attributes_required': [set(['geometry', 'node_id', 'pwr_plant', 'n_bldgs'])],
             'attributes': [set(['geometry', 'fltytype', 'strctype', 'utilfcltyc', 'indpnode', 'guid', 
                          'node_id', 'x_coord', 'y_coord', 'pwr_plant', 'serv_area', 'n_bldgs', 
-                         'income', 'eq_vuln'])]},
+                         'income', 'eq_frgl'])]},
         'power edges': {
             'render_order': 80,
             'data': solara.reactive(None),


### PR DESCRIPTION
The "eq_vuln" attribute is replaced with "eq_frgl". In the first webapp development, the taxonomy string was defined by means of "eq_vuln". Later, it is changed to "eq_frgl". However it is forgotten in the application state dictionary. This mistake has not caused any errors in calculation. Neverthless, we change it with the correct one which is "eq_frgl".