### PR TITLE
fix: remove metricX cols from building

### DIFF
--- a/tomorrowcities/backend/engine.py
+++ b/tomorrowcities/backend/engine.py
@@ -939,8 +939,6 @@ def generate_metrics(t, t_full, hazard_type, population_displacement_consensus):
             t['casualty'] == 1
         )
 
-    for j in range(1,10):
-        t[f'metric{j}'] = 0
 
     metric1 = len(t[is_unemployed])
     metric2 = len(t[lost_school])

--- a/tomorrowcities/pages/engine.py
+++ b/tomorrowcities/pages/engine.py
@@ -75,7 +75,7 @@ def create_new_app_state():
             'data': solara.reactive(None),
             'df': solara.reactive(None),
             'pre_processing': building_preprocess,
-            'extra_cols': {'freqincome': '', 'ds': 0, 'metric1': 0, 'metric2': 0, 'metric3': 0,'metric4': 0, 'metric5': 0,'metric6': 0,'metric7': 0, 'metric8': 0,
+            'extra_cols': {'freqincome': '', 'ds': 0,
                             'node_id': None,'hospital_access': True, 'has_power': True, 'casualty': 0},
             'filter_cols': ['expstr'],
             'attributes_required': [set(['residents', 'fptarea', 'repvalue', 'nhouse', 'zoneid', 'expstr', 'bldid', 'geometry', 'specialfac'])],


### PR DESCRIPTION
Since we moved into individual-based metrics, it is no longer necessary to keep metric1,...,metric8 columns in building data.