### PR TITLE
feature: get rid of local user authentication

### DIFF
--- a/tomorrowcities/pages/__init__.py
+++ b/tomorrowcities/pages/__init__.py
@@ -81,21 +81,6 @@ class User:
 
 
 user = solara.reactive(cast(Optional[User], read_from_session_storage('user')))
-login_failed = solara.reactive(False)
-
-
-def login_control(username: str, password: str):
-    # this function can be replace by a custom username/password check
-    if username == "test" and password == "test":
-        user.value = User(username, admin=False)
-        login_failed.value = False
-        store_in_session_storage('user', user.value)
-    elif username == "admin" and password == "admin":
-        user.value = User(username, admin=True)
-        login_failed.value = False
-        store_in_session_storage('user', user.value)
-    else:
-        login_failed.value = True
 
 
 @solara.component
@@ -125,12 +110,6 @@ def LoginForm():
             solara.Button(label="Login via GitHub", icon_name="mdi-github-circle", 
                 attributes={"href": github_authorization_url}, text=True, outlined=True,
                 on_click=lambda: store_in_session_storage('auth_company','github'))
-        solara.InputText(label="Username", value=username)
-        solara.InputText(label="Password", password=True, value=password)
-        solara.Button(label="Login", on_click=lambda: login_control(username.value, password.value))
-        if login_failed.value:
-            solara.Error("Wrong username or password")
-
 
 
 @solara.component

--- a/tomorrowcities/pages/account.py
+++ b/tomorrowcities/pages/account.py
@@ -5,7 +5,7 @@ import pprint
 from urllib.parse import parse_qs
 import json
 
-from . import user, User, login_failed, config, LoginForm, \
+from . import user, User, config, LoginForm, \
               github_client, google_client, \
               session_storage, read_from_session_storage, store_in_session_storage
 
@@ -72,8 +72,6 @@ def Page():
             username = user_dict['name']
             user.value = User(username, admin=False, auth_company=auth_company, user_profile=user_dict)
             
-            login_failed.value = False
-
             store_in_session_storage('user', user.value)
            
             # used only to force updating of the page


### PR DESCRIPTION
The intuition is that the maintaining the security of a local user authentication may bring additional burden for development. We would like to focus more on engine-related stuff. The users can authenticate via Google and GitHub. We can add LinkedIn, and other third-parth authentication sources in future if needed.