### PR TITLE
fix: clear session button is fixed

### DIFF
--- a/tomorrowcities/pages/explore.py
+++ b/tomorrowcities/pages/explore.py
@@ -251,7 +251,7 @@ def MetaDataViewer(session_name):
         print(metadata)
 
 def clear_session():
-    layers.value = create_new_app_state()
+    layers.set(create_new_app_state().value)
     force_render()
 
 def force_render():


### PR DESCRIPTION
clear session functionality was broken because
of a wrong reactive variable assignment.