### PR TITLE
feature: enabling test login for local environments

### DIFF
--- a/.env.global
+++ b/.env.global
@@ -21,6 +21,9 @@ google_redirect_uri=""
 google_client_id=""
 google_client_secret=""
 
+# enable single click test user login bypassing third-party authenticator
+enable_test_logon=False
+
 # S3 Storage
 aws_access_key_id=
 aws_secret_access_key=

--- a/tomorrowcities/pages/__init__.py
+++ b/tomorrowcities/pages/__init__.py
@@ -82,6 +82,10 @@ class User:
 
 user = solara.reactive(cast(Optional[User], read_from_session_storage('user')))
 
+def test_logon():
+    test_user = User(username="test", admin=False)
+    store_in_session_storage('user', test_user)
+    user.set(test_user)
 
 @solara.component
 def LoginForm():
@@ -110,6 +114,9 @@ def LoginForm():
             solara.Button(label="Login via GitHub", icon_name="mdi-github-circle", 
                 attributes={"href": github_authorization_url}, text=True, outlined=True,
                 on_click=lambda: store_in_session_storage('auth_company','github'))
+            if config.get('enable_test_logon', False):
+                solara.Button(label="Login via Local Test User", icon_name="mdi-account",
+                    text=True, outlined=True, on_click=test_logon)
 
 def logout():
     store_in_session_storage('user', None)


### PR DESCRIPTION
When the webapp is run on local environments without SSL and behind firewalls, third-party authenticators can not be used. In this case, a new option is added to the LoginForm so that the users can authenticate via a dummy test user.