### PR TITLE
fix: can't drop same file again

### DIFF
--- a/tomorrowcities/components/file_drop.vue
+++ b/tomorrowcities/components/file_drop.vue
@@ -26,6 +26,8 @@ module.exports = {
 
     this.$refs.dropzone.addEventListener('drop', async event => {
       event.preventDefault();
+      // Clear file information before processing new files
+      this.jupyter_clear();
       const items = await Promise.all([...event.dataTransfer.items]);
       const files = items.map(i => i.webkitGetAsEntry())
       const fileHolders = files.filter(f => f.isFile)


### PR DESCRIPTION
file_drop.vue script of FileDropMultiple component doesn't allow uploading same file. This is a problem especially when a user tries to make tests with the same set of files.