### PR TITLE
feat: enable data export for all spatial, non-spatial and GEM layers

### DIFF
--- a/tomorrowcities/content/articles/changelog.md
+++ b/tomorrowcities/content/articles/changelog.md
@@ -5,13 +5,47 @@ description: Details of the revisions applied
 image: https://github.com/TomorrowsCities/tomorrowcities/blob/main/tomorrowcities/content/images/changelog.png?raw=true
 thumbnail: https://github.com/TomorrowsCities/tomorrowcities/blob/main/tomorrowcities/content/images/changelog.png?raw=true
 alt: "Changelog"
-createdAt: 2023-01-18
-duration: 6 min read
+createdAt: 2026-01-18
+duration: 10 min read
 category:
   - general
 ---
 
-## What is New?
+**Changelog: v1.0**
+
+## What's Changed
+* feat: revamp home page, restructure navigation, consolidate pages and add utility tools by @o-z-e-r-e-r in [129](https://github.com/TomorrowsCities/tomorrowscities/pull/129)
+* refactor/ui: improve navbar/sidebar/docs and refactor metrics panels by @o-z-e-r-e-r in [128](https://github.com/TomorrowsCities/tomorrowscities/pull/128)
+* fix: Solara startup, hooks, calculation errors and data alignment by @o-z-e-r-e-r in [127](https://github.com/TomorrowsCities/tomorrowscities/pull/127)
+* ui: move settings by @hkayabilisim in [124](https://github.com/TomorrowsCities/tomorrowscities/pull/124)
+* ui: added favicon files by @hkayabilisim in [123](https://github.com/TomorrowsCities/tomorrowscities/pull/123)
+* ui: give extra info after data generation by @hkayabilisim in [122](https://github.com/TomorrowsCities/tomorrowscities/pull/122)
+* feat: probabilistic damage calculation for buildings on earthquake by @hkayabilisim in [119](https://github.com/TomorrowsCities/tomorrowscities/pull/119)
+
+## Highlights
+- Revamped home page and restructured navigation; consolidated pages and added utility tools.
+- Improved UI/UX across navbar/sidebar and metrics panels, including better mobile compatibility.
+- Stability and correctness fixes: Solara startup, hooks, calculation errors, and data alignment.
+- Added earthquake Monte Carlo simulation support (multiple runs) with UI controls and metric statistics.
+
+## Added
+- New/updated home page assets and icons; favicon support.
+- Earthquake Monte Carlo simulation with support for multiple runs.
+- UI options for earthquake simulation, plus metric statistics (e.g., boxplot/table).
+
+## Changed / Improved
+- Navigation and layout updates (navbar/sidebar) with refined styling and mobile improvements.
+- Metrics panels unified between pages for consistent layout and styling.
+- Settings/UI adjustments (e.g., moving population displacement consensus to Engine page).
+- Improved user feedback after data generation.
+- Page structure consolidated as part of the home/navigation revamp.
+
+## Fixed
+- Solara startup and hooks reliability.
+- Calculation errors and data alignment issues.
+
+**Full Changelog**: [v0.6...v1.0](https://github.com/TomorrowsCities/tomorrowscities/compare/v0.6...v1.0)
+
 
 **Changelog: v0.6**
 

--- a/tomorrowcities/content/articles/howtouse.md
+++ b/tomorrowcities/content/articles/howtouse.md
@@ -1,10 +1,10 @@
 ---
 author: o-z-e-r-e-r
-title: How to use WebApp
+title: How to Use WebApp
 description: Use instructions for TCDSE WebApp
 image: https://github.com/TomorrowsCities/tomorrowcities/blob/main/tomorrowcities/content/images/welcome.png?raw=true
 thumbnail: https://github.com/TomorrowsCities/tomorrowcities/blob/main/tomorrowcities/content/images/welcome.png?raw=true
-alt: "How to use WebApp"
+alt: "How to Use WebApp"
 createdAt: 2026-01-19
 duration: 20 min read
 category:

--- a/tomorrowcities/pages/engine.py
+++ b/tomorrowcities/pages/engine.py
@@ -1110,7 +1110,7 @@ def LayerDisplayer():
                     PowerFragilityDisplayer(data, items_per_page=5)
                 else:
                     solara.DataFrame(data, items_per_page=5)
-            if selected in ["building","road edges","road nodes","power nodes","power edges"] :
+            if selected in ["landuse","building","road edges","road nodes","power nodes","power edges","intensity"] :
                 with solara.Row():
                     file_object = data.to_json()
                     with solara.FileDownload(file_object, f"{selected}_export.geojson", mime_type="application/geo+json"):
@@ -1118,11 +1118,37 @@ def LayerDisplayer():
                     with solara.FileDownload(data.to_csv(), f"{selected}_export.csv", mime_type="text/csv"):
                         solara.Button("Download CSV", icon_name="mdi-cloud-download-outline", color="primary")
                 solara.Text("Spacer", style={"visibility": "hidden"})
+            elif selected in ['household', 'individual', 'fragility', 'landslide fragility', 'vulnerability', 'power fragility', 'road fragility']:
+                 with solara.Row():
+                    file_object = data.to_json()
+                    with solara.FileDownload(file_object, f"{selected}_export.json", mime_type="application/json"):
+                        solara.Button("Download JSON", icon_name="mdi-cloud-download-outline", color="primary")
+                    with solara.FileDownload(data.to_csv(), f"{selected}_export.csv", mime_type="text/csv"):
+                        solara.Button("Download CSV", icon_name="mdi-cloud-download-outline", color="primary")
+                 solara.Text("Spacer", style={"visibility": "hidden"})
         elif isinstance(data, ParameterFile):
             ParameterFileWidget(parameter_file=data)                        
         if selected == 'gem_vulnerability':
+            def default(obj):
+                if isinstance(obj, np.ndarray):
+                    return obj.tolist()
+                return str(obj)
+            with solara.Row():
+                file_object = json.dumps(data, default=default)
+                with solara.FileDownload(file_object, f"{selected}_export.json", mime_type="application/json"):
+                    solara.Button("Download JSON", icon_name="mdi-cloud-download-outline", color="primary")
+            solara.Text("Spacer", style={"visibility": "hidden"})
             VulnerabiliyDisplayer(data)
         elif selected == 'gem_fragility':
+            def default(obj):
+                if isinstance(obj, np.ndarray):
+                    return obj.tolist()
+                return str(obj)
+            with solara.Row():
+                file_object = json.dumps(data, default=default)
+                with solara.FileDownload(file_object, f"{selected}_export.json", mime_type="application/json"):
+                    solara.Button("Download JSON", icon_name="mdi-cloud-download-outline", color="primary")
+            solara.Text("Spacer", style={"visibility": "hidden"})
             FragilityDisplayer(data)
 
 metric_update_pending = solara.reactive(False)


### PR DESCRIPTION
This PR extends the data export functionality in the Engine page to cover all uploaded datasets.

1. Spatial Data Export: Users can now download landuse and intensity layers as both GEOJSON and CSV.
2. Tabular Data Export: Users can now download household, individual and various fragility/vulnerability layers as both JSON and CSV.
3. GEM Model Export: Added support for downloading gem_vulnerability and gem_fragility models as JSON.