### PR TITLE
fix: average Monte Carlo metrics for the impacts panel

### DIFF
--- a/tomorrowcities/pages/engine.py
+++ b/tomorrowcities/pages/engine.py
@@ -1183,6 +1183,17 @@ def generate_metrics_local():
             tally_filtered = tally_filtered[tally_filter.value]
         print('Triggering generate_metrics')
         metrics = generate_metrics(tally_filtered, tally_geo, hazard, population_displacement_consensus)
+        
+        is_unfiltered = (len(tally_filtered) == len(tally_geo))
+        if is_unfiltered:
+            realized = layers.value['metrics_realized'].value
+            if realized is not None and len(realized) > 1:
+                for metric_key in metrics.keys():
+                    avg_val = sum(trial[metric_key]['value'] for trial in realized) / len(realized)
+                    avg_max = sum(trial[metric_key]['max_value'] for trial in realized) / len(realized)
+                    metrics[metric_key]['value'] = int(round(avg_val))
+                    metrics[metric_key]['max_value'] = int(round(avg_max))
+        
         print('metrics', metrics)
     metric_update_pending.set(False)
     return metrics
@@ -1193,7 +1204,8 @@ def MetricPanel():
     solara.use_memo(generate_metrics_local, 
                     [tally_counter.value,
                      layers.value['bounds'].value,
-                     tally_filter.value], debug_name="generate_metrics_loca")
+                     tally_filter.value,
+                     layers.value['render_count'].value], debug_name="generate_metrics_loca")
     if generate_metrics_local.finished:
         filtered_metrics = generate_metrics_local.value
 

--- a/tomorrowcities/pages/explore.py
+++ b/tomorrowcities/pages/explore.py
@@ -333,10 +333,12 @@ def MapViewer():
 
     def create_base_layers():
         base_layer1 = ipyleaflet.TileLayer.element(url=ipyleaflet.basemaps.OpenStreetMap.Mapnik.build_url(),name="OpenStreetMap",base = True)
-        base_layer2 = ipyleaflet.TileLayer.element(url=ipyleaflet.basemaps.Esri.WorldStreetMap.build_url(),name="Esri WorldStreetMap",base = True)
-        base_layer3 = ipyleaflet.TileLayer.element(url=ipyleaflet.basemaps.OpenTopoMap.build_url(),name="OpenTopoMap",base = True)
-        base_layer4 = ipyleaflet.TileLayer.element(url=ipyleaflet.basemaps.CartoDB.Positron.build_url(),name="CartoDB",base = True)                                                                                                                                         
-        set_base_layers([base_layer4, base_layer3, base_layer2, base_layer1])
+        base_layer2 = ipyleaflet.TileLayer.element(url=ipyleaflet.basemaps.OpenTopoMap.build_url(),name="OpenTopoMap",base = True)
+        base_layer3 = ipyleaflet.TileLayer.element(url=ipyleaflet.basemaps.Esri.WorldStreetMap.build_url(),name="Esri WorldStreetMap",base = True)
+        base_layer4 = ipyleaflet.TileLayer.element(url=ipyleaflet.basemaps.Esri.WorldImagery.build_url(),name="Esri WorldImagery",base = True)        
+        base_layer5 = ipyleaflet.TileLayer.element(url=ipyleaflet.basemaps.CartoDB.Positron.build_url(),name="CartoDB",base = True) 
+        base_layer6 = ipyleaflet.TileLayer.element(url=ipyleaflet.basemaps.CartoDB.DarkMatter.build_url(),name="CartoDB Dark",base = True)                                                                                                                                        
+        set_base_layers([base_layer2, base_layer3, base_layer4, base_layer5, base_layer6, base_layer1])
 
     # create base layers only once
     solara.use_memo(create_base_layers,[])


### PR DESCRIPTION
This PR aligns the Impacts dashboard gauges with the aggregated Monte Carlo results by showing the expected value (average across all trials). While these statistics were already available in Metric Statistics/Stats, the gauges previously displayed only the latest iteration, which could be misleading. By aligning the dashboard gauges with the aggregated statistics across all trials, the dashboard now provides a more accurate and robust view of expected risk.